### PR TITLE
fix: zap borrow/withdraw target position

### DIFF
--- a/.changeset/mighty-eggs-grab.md
+++ b/.changeset/mighty-eggs-grab.md
@@ -1,0 +1,5 @@
+---
+'compound-kit-api': patch
+---
+
+fix zap borrow/withdraw target position

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-borrow/index.test.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-borrow/index.test.ts
@@ -64,7 +64,7 @@ describe('Test get zap borrow quotation api', function () {
       title: '200: zap borrow base token',
       path: '/v1/markets/137/usdc/zap-borrow',
       body: {
-        account: '0x34693b4b0e8237854cee68251441a0bf301c4d65',
+        account: '0x0FBeABcaFCf817d47E10a7bCFC15ba194dbD4EEF',
         amount: '1',
         targetToken: logics.compoundv3.polygonTokens.USDC,
         slippage: 100,
@@ -75,7 +75,7 @@ describe('Test get zap borrow quotation api', function () {
       title: '200: zap borrow USDT',
       path: '/v1/markets/137/usdc/zap-borrow',
       body: {
-        account: '0x34693b4b0e8237854cee68251441a0bf301c4d65',
+        account: '0x0FBeABcaFCf817d47E10a7bCFC15ba194dbD4EEF',
         amount: '1',
         targetToken: {
           chainId: 137,

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-borrow/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-borrow/index.ts
@@ -117,7 +117,7 @@ export const v1GetZapBorrowQuotationRoute: Route<GetZapBorrowQuotationRouteParam
       approvals = estimateResult.approvals;
 
       // 5. calc target position
-      const curBorrowUSD = new BigNumberJS(targetTokenAmount).times(baseTokenPrice);
+      const curBorrowUSD = new BigNumberJS(amount).times(baseTokenPrice);
       const targetSupplyUSD = new BigNumberJS(supplyUSD);
       const targetBorrowUSD = new BigNumberJS(borrowUSD).plus(curBorrowUSD);
       const targetCollateralUSD = new BigNumberJS(collateralUSD);

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-repay/index.test.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-repay/index.test.ts
@@ -56,7 +56,7 @@ describe('Test get zap repay quotation api', function () {
       title: '200: zap repay ERC20 token',
       path: '/v1/markets/137/usdc/zap-repay',
       body: {
-        account: '0xf6da9e9d73d7893223578d32a95d6d7de5522767',
+        account: '0x0fbeabcafcf817d47e10a7bcfc15ba194dbd4eef',
         sourceToken: {
           chainId: 137,
           address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
@@ -77,7 +77,7 @@ describe('Test get zap repay quotation api', function () {
       title: '200: zap repay base token',
       path: '/v1/markets/137/usdc/zap-repay',
       body: {
-        account: '0xf6da9e9d73d7893223578d32a95d6d7de5522767',
+        account: '0x0fbeabcafcf817d47e10a7bcfc15ba194dbd4eef',
         sourceToken: logics.compoundv3.polygonTokens.USDC,
         amount: '1',
         slippage: 100,

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-supply/index.test.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-supply/index.test.ts
@@ -57,7 +57,7 @@ describe('Test get zap supply quotation api', function () {
       title: '400.6: borrow USD is not zero',
       path: '/v1/markets/137/usdc/zap-supply',
       body: {
-        account: '0xf6da9e9d73d7893223578d32a95d6d7de5522767',
+        account: '0x0fbeabcafcf817d47e10a7bcfc15ba194dbd4eef',
         sourceToken: {
           chainId: 137,
           address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.test.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.test.ts
@@ -121,7 +121,7 @@ describe('Test get zap withdraw quotation api', function () {
       title: '200: zap withdraw base token',
       path: '/v1/markets/137/usdc/zap-withdraw',
       body: {
-        account: '0x8238892095d3bac5322894e84f349bcd52f843d5',
+        account: '0x43158f45b5EbD7b1179130130DF00393928C2691',
         withdrawalToken: logics.compoundv3.polygonTokens.USDC,
         amount: '1',
         targetToken: {
@@ -157,7 +157,7 @@ describe('Test get zap withdraw quotation api', function () {
       title: '200: withdrawal token is target token',
       path: '/v1/markets/137/usdc/zap-withdraw',
       body: {
-        account: '0x8238892095d3bac5322894e84f349bcd52f843d5',
+        account: '0x43158f45b5EbD7b1179130130DF00393928C2691',
         withdrawalToken: logics.compoundv3.polygonTokens.USDC,
         amount: '1',
         targetToken: logics.compoundv3.polygonTokens.USDC,

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.ts
@@ -151,13 +151,13 @@ export const v1GetZapWithdrawQuotationRoute: Route<GetZapWithdrawQuotationRouteP
       // 3. calc target position
       let targetSupplyUSD, targetCollateralUSD, targetBorrowCapacityUSD, targetLiquidationLimit;
       if (realWithdrawalToken.unwrapped.is(baseToken)) {
-        const withdrawalUSD = new BigNumberJS(targetTokenAmount).times(baseTokenPrice);
+        const withdrawalUSD = new BigNumberJS(amount).times(baseTokenPrice);
         targetSupplyUSD = new BigNumberJS(supplyUSD).minus(withdrawalUSD);
         targetCollateralUSD = new BigNumberJS(collateralUSD);
         targetBorrowCapacityUSD = new BigNumberJS(borrowCapacityUSD);
         targetLiquidationLimit = new BigNumberJS(liquidationLimit);
       } else {
-        const withdrawalUSD = new BigNumberJS(targetTokenAmount).times(withdrawalCollateral!.assetPrice);
+        const withdrawalUSD = new BigNumberJS(amount).times(withdrawalCollateral!.assetPrice);
         targetSupplyUSD = new BigNumberJS(supplyUSD);
         targetCollateralUSD = new BigNumberJS(collateralUSD).minus(withdrawalUSD);
         targetBorrowCapacityUSD = new BigNumberJS(borrowCapacityUSD).minus(

--- a/test/transactions/zap-borrow.ts
+++ b/test/transactions/zap-borrow.ts
@@ -18,7 +18,7 @@ describe('Transaction: Zap Borrow', function () {
 
   before(async function () {
     chainId = await getChainId();
-    user = await hre.ethers.getImpersonatedSigner('0xf6da9e9d73d7893223578d32a95d6d7de5522767');
+    user = await hre.ethers.getImpersonatedSigner('0x0FBeABcaFCf817d47E10a7bCFC15ba194dbD4EEF');
     service = new logics.compoundv3.Service(chainId, hre.ethers.provider);
     initBorrowBalance = await service.getBorrowBalance(marketId, user.address, baseToken);
   });


### PR DESCRIPTION
**Issue**
- Use `targetTokenAmount` to calculate `curBorrowUSD` and `withdrawalUSD` resulting in wrong `targetPosition`

**Solution**
- Use `amount` instead

**Checklist**
- [x] fix curBorrowUSD
- [x] fix withdrawalUSD
- [x] yarn changeset