### PR TITLE
fix: target position of zaps

### DIFF
--- a/.changeset/fluffy-bobcats-whisper.md
+++ b/.changeset/fluffy-bobcats-whisper.md
@@ -1,0 +1,5 @@
+---
+'compound-kit-api': patch
+---
+
+fix liquidationThreshold of zap supply and withdraw

--- a/.changeset/metal-terms-add.md
+++ b/.changeset/metal-terms-add.md
@@ -1,0 +1,5 @@
+---
+'compound-kit-api': patch
+---
+
+fix borrowUSD of zap repay

--- a/.changeset/sixty-penguins-work.md
+++ b/.changeset/sixty-penguins-work.md
@@ -1,0 +1,5 @@
+---
+'compound-kit-api': patch
+---
+
+fix targetBorrowCapacityUSD of zap withdraw

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-repay/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-repay/index.ts
@@ -123,7 +123,9 @@ export const v1GetZapRepayQuotationRoute: Route<GetZapRepayQuotationRouteParams>
       // 4. calc target position
       const repayUSD = new BigNumberJS(destAmount).times(baseTokenPrice);
       const targetSupplyUSD = new BigNumberJS(supplyUSD);
-      const targetBorrowUSD = new BigNumberJS(borrowUSD).minus(repayUSD);
+      const targetBorrowUSD = new BigNumberJS(borrowUSD).gt(repayUSD)
+        ? new BigNumberJS(borrowUSD).minus(repayUSD)
+        : new BigNumberJS(0);
       const targetCollateralUSD = new BigNumberJS(collateralUSD);
       const targetBorrowCapacityUSD = new BigNumberJS(borrowCapacityUSD);
       const targetLiquidationLimit = new BigNumberJS(liquidationLimit);

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-supply/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-supply/index.ts
@@ -163,7 +163,9 @@ export const v1GetZapSupplyQuotationRoute: Route<GetZapSupplyQuotationRouteParam
         );
       }
       const targetBorrowUSD = new BigNumberJS(borrowUSD);
-      const targetLiquidationThreshold = common.formatBigUnit(targetLiquidationLimit.div(targetCollateralUSD), 4);
+      const targetLiquidationThreshold = !targetCollateralUSD.isZero()
+        ? common.formatBigUnit(targetLiquidationLimit.div(targetCollateralUSD), 4)
+        : '0';
       const targetPositiveProportion = targetSupplyUSD.times(supplyAPR);
       const targetNegativeProportion = targetBorrowUSD.times(borrowAPR);
 

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.ts
@@ -177,7 +177,9 @@ export const v1GetZapWithdrawQuotationRoute: Route<GetZapWithdrawQuotationRouteP
       }
 
       const targetBorrowUSD = new BigNumberJS(borrowUSD);
-      const targetLiquidationThreshold = common.formatBigUnit(targetLiquidationLimit.div(targetCollateralUSD), 4);
+      const targetLiquidationThreshold = !targetCollateralUSD.isZero()
+        ? common.formatBigUnit(targetLiquidationLimit.div(targetCollateralUSD), 4)
+        : '0';
       const targetPositiveProportion = targetSupplyUSD.times(supplyAPR);
       const targetNegativeProportion = targetBorrowCapacityUSD.times(borrowAPR);
       targetPosition = {

--- a/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/zap-withdraw/index.ts
@@ -169,7 +169,7 @@ export const v1GetZapWithdrawQuotationRoute: Route<GetZapWithdrawQuotationRouteP
         targetSupplyUSD = new BigNumberJS(supplyUSD);
         targetCollateralUSD = new BigNumberJS(collateralUSD).minus(withdrawalUSD);
         targetBorrowCapacityUSD = new BigNumberJS(borrowCapacityUSD).minus(
-          withdrawalUSD.times(srcCollateral!.borrowCapacity)
+          withdrawalUSD.times(srcCollateral!.borrowCollateralFactor)
         );
         targetLiquidationLimit = new BigNumberJS(liquidationLimit).minus(
           withdrawalUSD.times(srcCollateral!.liquidateCollateralFactor)
@@ -182,6 +182,7 @@ export const v1GetZapWithdrawQuotationRoute: Route<GetZapWithdrawQuotationRouteP
         : '0';
       const targetPositiveProportion = targetSupplyUSD.times(supplyAPR);
       const targetNegativeProportion = targetBorrowCapacityUSD.times(borrowAPR);
+
       targetPosition = {
         utilization: calcUtilization(targetBorrowCapacityUSD, targetBorrowUSD),
         healthRate: calcHealthRate(targetCollateralUSD, targetBorrowUSD, targetLiquidationThreshold),


### PR DESCRIPTION
### Issue

- `borrowUSD` becomes negative when `repayUSD > borrowUSD` (zap-repay)
- `liquidationThreshold` is `NaN` when the user has no collateral (zap-supply & zap-withdraw)
- `utilization` & `netAPR` are incorrect (zap-withdraw)

### Solution

- check `borrowUSD > repayUSD`
- check `targetCollateralUSD == 0`
- fix the calculation of `targetBorrowCapacityUSD`

### CheckIist
- [x] fix
- [x] changeset


