### PR TITLE
fix: targetLiquidationLimit of collateral swap

### DIFF
--- a/.changeset/beige-shrimps-drive.md
+++ b/.changeset/beige-shrimps-drive.md
@@ -1,0 +1,5 @@
+---
+'compound-kit-api': patch
+---
+
+fix targetLiquidationLimit of collateral swap

--- a/src/handlers/v1/markets/[chainId]/[marketId]/collateral-swap/index.ts
+++ b/src/handlers/v1/markets/[chainId]/[marketId]/collateral-swap/index.ts
@@ -148,11 +148,9 @@ export const v1GetCollateralSwapQuotationRoute: Route<GetCollateralSwapQuotation
       const targetCollateralUSD = new BigNumberJS(collateralUSD).minus(withdrawalUSD).plus(targetUSD);
       const targetBorrowCapacityUSD = new BigNumberJS(borrowCapacityUSD);
 
-      const targetLiquidationLimit = new BigNumberJS(liquidationLimit).minus(
-        withdrawalUSD
-          .times(srcCollateral.liquidateCollateralFactor)
-          .plus(targetUSD.times(destCollateral.liquidateCollateralFactor))
-      );
+      const targetLiquidationLimit = new BigNumberJS(liquidationLimit)
+        .minus(withdrawalUSD.times(srcCollateral.liquidateCollateralFactor))
+        .plus(targetUSD.times(destCollateral.liquidateCollateralFactor));
       const targetLiquidationThreshold = common.formatBigUnit(targetLiquidationLimit.div(targetCollateralUSD), 4);
       const targetPositiveProportion = targetSupplyUSD.times(supplyAPR);
       const targetNegativeProportion = targetBorrowUSD.times(borrowAPR);


### PR DESCRIPTION
Issue

- `healthRate` & `liquidationThreshold` are incorrect in target position

Solution

- fix the calculation of `targetLiquidationLimit`

Checklist

- [x] fix
- [x] changeset